### PR TITLE
Align text in lemonbar config "clock.sh"

### DIFF
--- a/scripts/lemonbar/clock.sh
+++ b/scripts/lemonbar/clock.sh
@@ -41,4 +41,4 @@ while :; do
 	sleep 2s
 done |
 
-lemonbar -d -b -g "1000x75+1100+50" -f "roboto-16" -f "fontawesome-18" -B "#$white" -F "#$gray"
+lemonbar -d -b -g "1000x75+1100+50" -f "roboto-16" -o 0 -f "fontawesome-18" -o -2 -B "#$white" -F "#$gray"


### PR DESCRIPTION
Aligned the fontawesome text in the lemonbar config "clock.sh" with the roberto text. This is done with lemonbars "-o" option, which when used on multiple fonts in the config algns their height relative to 0 individually. 

Difference can be seen here (top one contains the change):

![New Aligned](http://imgur.com/eXvKyZB.png)
![Old Misaligned](http://imgur.com/UBlnyA0.png)

That bar in the pictures contain other changes that aren't in this pull request, this is just the alignment fix.
